### PR TITLE
chore: let frontend-platform version float a little to fix conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
         "@edx/frontend-component-footer": "^10.2.1",
         "@edx/frontend-component-header": "^2.4.5",
-        "@edx/frontend-platform": "1.15.1",
+        "@edx/frontend-platform": "^1.15.1",
         "@edx/paragon": "19.6.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.14",
         "@fortawesome/free-brands-svg-icons": "^5.7.2",
@@ -2214,19 +2214,19 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.1.tgz",
-      "integrity": "sha512-vi2iG01z/mvlxKbgozGkZQTbchliq6MJ9tY4CpYy1CMjt5Rn/PDaS2sK6FKhuAlyQAR4ZqFWHrwM1wednG9RQQ==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.6.tgz",
+      "integrity": "sha512-hvcJwRLy4JBdyBjHgu11nrqmMTWI901q6Ax83pf+yQpz68PpsJ0KdFjerxnkNJjU//XrWUuhSLesOPY2ntIjjg==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
-        "axios": "0.21.4",
+        "axios": "0.26.1",
         "axios-cache-adapter": "2.7.3",
         "form-urlencoded": "4.1.4",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "history": "4.10.1",
         "i18n-iso-countries": "4.3.1",
         "jwt-decode": "3.1.2",
-        "localforage": "1.9.0",
+        "localforage": "1.10.0",
         "localforage-memoryStorageDriver": "0.9.2",
         "lodash.camelcase": "4.3.0",
         "lodash.memoize": "4.1.2",
@@ -2250,6 +2250,14 @@
         "redux": "^4.0.4"
       }
     },
+    "node_modules/@edx/frontend-platform/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/@edx/frontend-platform/node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -2262,25 +2270,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.1.4.tgz",
       "integrity": "sha512-R7Vytos0gMYuPQTMwnNzvK9PBItNV+Qkm/pvghEZI3j2kMrzZmJlczAgHFmt12VV+IRYQXgTlSGP1PKAsMCIUA=="
-    },
-    "node_modules/@edx/frontend-platform/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/@edx/frontend-platform/node_modules/i18n-iso-countries": {
       "version": "4.3.1",
@@ -16318,9 +16307,9 @@
       }
     },
     "node_modules/localforage": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
-      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -26846,19 +26835,19 @@
       }
     },
     "@edx/frontend-platform": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.1.tgz",
-      "integrity": "sha512-vi2iG01z/mvlxKbgozGkZQTbchliq6MJ9tY4CpYy1CMjt5Rn/PDaS2sK6FKhuAlyQAR4ZqFWHrwM1wednG9RQQ==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.6.tgz",
+      "integrity": "sha512-hvcJwRLy4JBdyBjHgu11nrqmMTWI901q6Ax83pf+yQpz68PpsJ0KdFjerxnkNJjU//XrWUuhSLesOPY2ntIjjg==",
       "requires": {
         "@cospired/i18n-iso-languages": "2.2.0",
-        "axios": "0.21.4",
+        "axios": "0.26.1",
         "axios-cache-adapter": "2.7.3",
         "form-urlencoded": "4.1.4",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "history": "4.10.1",
         "i18n-iso-countries": "4.3.1",
         "jwt-decode": "3.1.2",
-        "localforage": "1.9.0",
+        "localforage": "1.10.0",
         "localforage-memoryStorageDriver": "0.9.2",
         "lodash.camelcase": "4.3.0",
         "lodash.memoize": "4.1.2",
@@ -26869,6 +26858,14 @@
         "universal-cookie": "4.0.4"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
         "cookie": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -26878,19 +26875,6 @@
           "version": "4.1.4",
           "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.1.4.tgz",
           "integrity": "sha512-R7Vytos0gMYuPQTMwnNzvK9PBItNV+Qkm/pvghEZI3j2kMrzZmJlczAgHFmt12VV+IRYQXgTlSGP1PKAsMCIUA=="
-        },
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
         },
         "i18n-iso-countries": {
           "version": "4.3.1",
@@ -37731,9 +37715,9 @@
       }
     },
     "localforage": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
-      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "requires": {
         "lie": "3.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
     "@edx/frontend-component-footer": "^10.2.1",
     "@edx/frontend-component-header": "^2.4.5",
-    "@edx/frontend-platform": "1.15.1",
+    "@edx/frontend-platform": "^1.15.1",
     "@edx/paragon": "19.6.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-brands-svg-icons": "^5.7.2",


### PR DESCRIPTION
The actual current version is way past this but right now I just want to get this deployable with minimal changes. The build error is a conflict between fixed 1.15.1 and required 1.15.2 or higher, not replicated locally.