### PR TITLE
fix: constrain header more tightly to avoid breaking changes at about 6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@cospired/i18n-iso-languages": "^2.0.2",
         "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
         "@edx/frontend-component-footer": "^4.4.2",
-        "@edx/frontend-component-header": "^6.3.9",
+        "@edx/frontend-component-header": "~6.3.9",
         "@edx/frontend-platform": "^2.0.0",
         "@edx/paragon": "~19.9.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.14",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@cospired/i18n-iso-languages": "^2.0.2",
     "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
     "@edx/frontend-component-footer": "^4.4.2",
-    "@edx/frontend-component-header": "^6.3.9",
+    "@edx/frontend-component-header": "~6.3.9",
     "@edx/frontend-platform": "^2.0.0",
     "@edx/paragon": "~19.9.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.14",


### PR DESCRIPTION
this is to match changes I'm making in the edx-internal files to prevent them from going up to 6.5 since the CI doesn't seem to care that package lock here has 6.3.9 in it.