### PR TITLE
chore: update footer version to 4.6ish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cospired/i18n-iso-languages": "^2.0.2",
         "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
-        "@edx/frontend-component-footer": "^4.4.2",
+        "@edx/frontend-component-footer": "~4.6.0",
         "@edx/frontend-component-header": "~6.3.9",
         "@edx/frontend-platform": "^2.0.0",
         "@edx/paragon": "~19.9.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@cospired/i18n-iso-languages": "^2.0.2",
     "@edx/brand": "npm:@edx/brand-openedx@^1.1.0",
-    "@edx/frontend-component-footer": "^4.4.2",
+    "@edx/frontend-component-footer": "~4.6.0",
     "@edx/frontend-component-header": "~6.3.9",
     "@edx/frontend-platform": "^2.0.0",
     "@edx/paragon": "~19.9.0",


### PR DESCRIPTION
4.6.0 is what is in package-lock, make it official so we can align properly with edx-internal